### PR TITLE
update htop to 2.0.1

### DIFF
--- a/app.sh
+++ b/app.sh
@@ -7,9 +7,24 @@ local URL="http://ftp.gnu.org/gnu/ncurses/${FILE}"
 
 _download_tgz "${FILE}" "${URL}" "${FOLDER}"
 pushd target/"${FOLDER}"
+
+# htop's configure script explicitly looks for libtinfo, which, it seems, is
+# now included as part of libncurses(w) by default. in lieu of fixing what
+# appears to be an "upstream" problem with htop, we avoid linking errors by
+# specifying the --with-termlib=tinfo arg to build tinfo as a separate library
+# named 'libtinfo'.
+#
+# note that without specifying the name, tinfo will get built as 'libtinfow'
+# (due to the --enable-widec argument) which again trips's up htop's configure
+# script, which is still looking for libtinfo. :-/
+#
+# another workaround for this mess would be to not include the --with-termlib
+# arg and just symlink libtinfo to libncursesw. however, building the separate
+# library feels (slightly) more appropriate.
+#
 ./configure --host="${HOST}" --prefix="${DEPS}" \
   --libdir="${DEST}/lib" --datadir="${DEST}/share" \
-  --with-shared --enable-rpath --enable-widec
+  --with-shared --enable-rpath --enable-widec --with-termlib=tinfo
 make
 make install
 rm -v "${DEST}/lib"/*.a

--- a/app.sh
+++ b/app.sh
@@ -18,7 +18,7 @@ popd
 
 ### HTOP ###
 _build_htop() {
-local VERSION="1.0.3"
+local VERSION="2.0.1"
 local FOLDER="htop-${VERSION}"
 local FILE="${FOLDER}.tar.gz"
 local URL="http://hisham.hm/htop/releases/${VERSION}/${FILE}"

--- a/app.sh
+++ b/app.sh
@@ -42,7 +42,7 @@ _download_tgz "${FILE}" "${URL}" "${FOLDER}"
 pushd target/"${FOLDER}"
 ./configure --host="${HOST}" --prefix="${DEST}" \
   --mandir="${DEST}/man" \
-  --enable-unicode --disable-native-affinity \
+  --enable-unicode \
   ac_cv_func_malloc_0_nonnull=yes \
   ac_cv_func_realloc_0_nonnull=yes \
   ac_cv_file__proc_stat=yes \

--- a/build.sh
+++ b/build.sh
@@ -29,6 +29,8 @@ export DEPS="${PWD}/target/install"
 export CFLAGS="${CFLAGS:-} -Os -fPIC"
 export CXXFLAGS="${CXXFLAGS:-} ${CFLAGS}"
 export CPPFLAGS="-I${DEPS}/include"
+# NOTE: use the --verbose option when debugging library linking problems
+# export LDFLAGS="${LDFLAGS:-} -Wl,--verbose,-rpath,${DEST}/lib -L${DEST}/lib"
 export LDFLAGS="${LDFLAGS:-} -Wl,-rpath,${DEST}/lib -L${DEST}/lib"
 alias make="make -j4 V=1 VERBOSE=1"
 

--- a/src/dest/service.sh
+++ b/src/dest/service.sh
@@ -7,7 +7,7 @@
 
 framework_version="2.1"
 name="htop"
-version="1.0.3-1"
+version="2.0.1"
 description="Interactive process viewer for text-mode consoles"
 depends=""
 webui=""


### PR DESCRIPTION
this PR updates htop from 1.0.3 to 2.0.1, bringing it a bit more up to date. (see [changelog](https://github.com/hishamhm/htop/blob/e2ccc7b2408dc4e0b99f7b5446465bea9db0a23e/ChangeLog).)
#### notes
- ncurses is still at v5.9 and that appears to be fine. i decided against upgrading ncurses to v6 because i had enough trouble debugging the linking issues i had. (see the comment in `app.sh` at 3402dbe.)
- to use unicode support, you need `LC_ALL` set to `en_US.UTF-8`. i ended up putting `export LC_ALL=en_US.UTF-8` and `export LANG=en_US.UTF-8` (to override the default `C` value and keep things sane) in my `~/.profile`. (this tidbit probably belongs in the README.)

built via the droboports/compiler docker container and installed/tested on my 5n (firmware 3.5.10).
